### PR TITLE
Enable local test execution with mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "./scripts/build.sh",
     "build-for-offline": "npm run build && ./scripts/build-for-offline.sh",
-    "test": ""
+    "test": "",
+    "kata-tests": "./node_modules/.bin/mocha --compilers js:babel-core/register --require ./test/mocha_helper.js"
   },
   "repository": {
     "type": "git",
@@ -19,6 +20,8 @@
   },
   "homepage": "https://github.com/tddbin/katas",
   "devDependencies": {
-    "push2gh-pages": "git://github.com/uxebu/push2gh-pages.git"
+    "push2gh-pages": "git://github.com/uxebu/push2gh-pages.git",
+    "mocha": "^2.2.4",
+    "babel-core": "^5.1.11"
   }
 }

--- a/test/mocha_helper.js
+++ b/test/mocha_helper.js
@@ -1,0 +1,1 @@
+global.assert = require('assert');


### PR DESCRIPTION
This allows solving the katas locally, e.g. using `:!npm test %` in vim.

How you "test" your katas when writing them (I assume directly against a local tddbin-frontend)? Do you find this useful? Maybe you want to use a different command than `test`, because test will always be red by definition?
