### PR TITLE
Clearer hint.

### DIFF
--- a/katas/es6/language/class/more-extends.js
+++ b/katas/es6/language/class/more-extends.js
@@ -25,7 +25,7 @@ describe('class can inherit from another', () => {
   });
 
   describe('`extends` using an expression', () => {
-    it('like the inline assignment of the parent class', () => {
+    it('eg the inline assignment of the parent class', () => {
       let A;
       class B extends (A = {}) {}
       


### PR DESCRIPTION
While solving the Kata I thought both classes should be declared inline. With "eg" instead of "like" it might be clearer.