### PR TITLE
Reflect.construct should have argumentsList by default, even if it's …

### DIFF
--- a/katas/es6/language/reflect/basics.js
+++ b/katas/es6/language/reflect/basics.js
@@ -25,7 +25,7 @@ describe('`Reflect` basics', function() {
     
     it('`Reflect.construct()` is like new', function() {
       let Class;
-      assert.equal(Reflect.construct(Class) instanceof Class, true);
+      assert.equal(Reflect.construct(Class, []) instanceof Class, true);
     });
     
     it('`Reflect.get()` returns a property`s value', function() {


### PR DESCRIPTION
… empty

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/construct

closes https://github.com/tddbin/es6katas.org/issues/30