### PR TITLE
Make test fail properly

### DIFF
--- a/katas/es6/language/reflect/construct.js
+++ b/katas/es6/language/reflect/construct.js
@@ -17,7 +17,7 @@ describe('`Reflect.construct` is the `new` operator as a function', function() {
   describe('the 1st parameter is the constructor to be invoked', function() {
     it('fails when given a number as constructor', function() {
       let aNumber = () => {};
-      assert.throws(() => { Reflect.construct(aNumber) }, TypeError);
+      assert.throws(() => { Reflect.construct(aNumber, []) }, TypeError);
     });
     it('works giving a function', function() {
       let aFunction;


### PR DESCRIPTION
The test `fails when given a number as constructor` passes even when you pass something else than a number as paramater to `Reflect.construct()` because it’s missing the second parameter (argument list).

See http://tddbin.com/#?kata=es6/language/reflect/construct and our little chit chat over here: https://twitter.com/mkuehnel/status/772521342059028480