### PR TITLE
Rename to katafy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,5 +3,5 @@
 
 # v2
 
-- [ ] Kataify all ES6 katas
+- [ ] Katafy all ES6 katas
 

--- a/docs/adr/003-kataification.md
+++ b/docs/adr/003-kataification.md
@@ -1,4 +1,4 @@
-# 3. Kataification
+# 3. Katafication
 
 ## Status
 
@@ -13,7 +13,7 @@ the kata is run on supports a certain feature.
 
 ## Decision
 
-All tests have to pass and the special comment `////` marks how to kataify
+All tests have to pass and the special comment `////` marks how to katafy
 this test.
 For example:
 ```
@@ -21,7 +21,7 @@ For example:
       const expectedType = 'object';
       assert.equal(typeof Reflect, expectedType);
 ```
-The above test passes. Kataify means uncomment the first line and remove the following line, so
+The above test passes. Katafy means uncomment the first line and remove the following line, so
 that the code looks like this afterwards:
 ```
       const expectedType = 'not a function!';
@@ -35,5 +35,5 @@ The tests can be used as tests and katas. Additionally it can be assured
 automatically if a kata would be solvable.
 How? Just run the test, that should fail on that platform (e.g. because the
 JS engine does not support all features or just an older version of ECMAScript).
-If the test passes, the feature is supported. Now kataify the
+If the test passes, the feature is supported. Now katafy the
 test and the user can start solving the kata and learn.

--- a/src/convert-tests-to-katas/index.js
+++ b/src/convert-tests-to-katas/index.js
@@ -11,7 +11,7 @@ export const convertTestsToKatas = ({sourceDir, destinationDir}) => {
     findFilenames: () => allFilesInDir(sourceDir),
     rootDir: sourceDir,
   };
-  const kataifyDeps = {
+  const katafyDeps = {
     readFile: readFileAsString,
     writeFile: writeFileFromString,
   };
@@ -23,6 +23,6 @@ export const convertTestsToKatas = ({sourceDir, destinationDir}) => {
     .forKataFiles()
     .then(files => toSrcDestPairs(files, toSrcDestPairsDeps))
     .then(pairs => createDestinationDirs(pairs, {mkdirp}).then(() => pairs))
-    .then(pairs => katafy(pairs, kataifyDeps))
+    .then(pairs => katafy(pairs, katafyDeps))
   ;
 };

--- a/src/convert-tests-to-katas/index.spec.js
+++ b/src/convert-tests-to-katas/index.spec.js
@@ -16,7 +16,7 @@ describe('Convert tests to katas', () => {
   it('THEN creates all missing destination directories', () => {
 
   });
-  it('THEN kataifies all tests', () => {
+  it('THEN katafies all tests', () => {
 
   });
 });

--- a/src/convert-tests-to-katas/katafier.js
+++ b/src/convert-tests-to-katas/katafier.js
@@ -1,11 +1,11 @@
 // @flow
-type KataifyableType = {
+type KatafyableType = {
   sourceFilename: string;
   destinationFilename: string;
 };
-type KataifyableListType = Array<KataifyableType>;
+type KatafyableListType = Array<KatafyableType>;
 
-type KataifyDeps = {
+type KatafyDeps = {
   readFile: (FilenameType) => Promise<*>;
   writeFile: (FilenameType, string) => Promise<*>;
 };
@@ -26,14 +26,14 @@ export const katafyFile = (fileContent: string): string =>
   ;
 
 export const katafy = (
-  kataifyableList: KataifyableListType,
-  {readFile, writeFile}: KataifyDeps
+  katafyableList: KatafyableListType,
+  {readFile, writeFile}: KatafyDeps
 ): Promise<*> => {
-  const kataifyableToTask = (kataifyable) =>
-    readFile(kataifyable.sourceFilename)
+  const katafyableToTask = (katafyable) =>
+    readFile(katafyable.sourceFilename)
       .then(katafyFile)
-      .then(content => writeFile(kataifyable.destinationFilename, content))
+      .then(content => writeFile(katafyable.destinationFilename, content))
     ;
 
-  return Promise.all(kataifyableList.map(kataifyableToTask));
+  return Promise.all(katafyableList.map(katafyableToTask));
 };

--- a/src/convert-tests-to-katas/katafier.spec.js
+++ b/src/convert-tests-to-katas/katafier.spec.js
@@ -8,7 +8,7 @@ import {
 } from 'hamjest-spy';
 import { katafyFile, katafy } from './katafier';
 
-describe('Kataify files', () => {
+describe('Katafy files', () => {
   const defaultDeps = () => {
     return {
       readFile: buildFunctionSpy({ returnValue: Promise.resolve('') }),
@@ -21,7 +21,7 @@ describe('Kataify files', () => {
     await katafy([], deps);
     assertThat(deps.readFile, wasNotCalled());
   });
-  describe('WHEN one kataifyable file given', () => {
+  describe('WHEN one katafyable file given', () => {
     const oneFile = {
       sourceFilename: '/src/file.js',
       destinationFilename: '/dest/file.js',
@@ -38,7 +38,7 @@ describe('Kataify files', () => {
       await katafy([oneFile], deps);
       assertThat(deps.writeFile, wasCalledWith(oneFile.destinationFilename, originalContent));
     });
-    it('AND it is a kata, write the kataified file content', async () => {
+    it('AND it is a kata, write the katafied file content', async () => {
       const originalContent = [
         '////Only this line will be left',
         'let oldCode;'
@@ -48,7 +48,7 @@ describe('Kataify files', () => {
       assertThat(deps.writeFile, wasCalledWith(oneFile.destinationFilename, 'Only this line will be left'));
     });
   });
-  describe('WHEN multiple kataifyable files given', () => {
+  describe('WHEN multiple katafyable files given', () => {
     const twoFiles = [
       { sourceFilename: '/src/file1.js', destinationFilename: '/dest/file1.js' },
       { sourceFilename: '/src/file2.js', destinationFilename: '/dest/file2.js' },
@@ -82,7 +82,7 @@ describe('Kataify files', () => {
   });
 });
 
-describe('Kataify file content', () => {
+describe('Katafy file content', () => {
   it('WHEN empty return empty', () => {
     assertThat(katafyFile(''), equalTo(''));
   });


### PR DESCRIPTION
`kataify` to `katafy` Learned from natives that this seems more logical, and it's simpler :).