### PR TITLE
[es6][template strings] change return value for function call

### DIFF
--- a/katas/es6/language/template-strings/basics.js
+++ b/katas/es6/language/template-strings/basics.js
@@ -34,12 +34,12 @@ describe('A template string, is wrapped in ` (backticks) instead of \' or "', fu
       assert.equal(evaluated, x+y);
     });
     it('inside "${...}" can also be a function call', function() {
-      function getDomain(){ 
-        return document.domain; 
+      function getEnv(){
+        return 'ECMAScript';
       }
-      //// var evaluated = `${ getDomain }`;
-      var evaluated = `${ getDomain() }`;
-      assert.equal(evaluated, 'tddbin.com');
+      //// var evaluated = `${ getEnv }`;
+      var evaluated = `${ getEnv() }`;
+      assert.equal(evaluated, 'ECMAScript');
     });
   });
 });


### PR DESCRIPTION
While the test will work fine on tddbin.com, that is a hard dependency
on the domain to run the tests. This change removes that hard
dependency and uses a string return value so that the tests can be run
even from the command line and still get it to pass.