### PR TITLE
[es6][rest] change use of `arguments` keyword in `eliminate arguments…

### DIFF
--- a/katas/es6/language/rest/as-parameter.js
+++ b/katas/es6/language/rest/as-parameter.js
@@ -24,7 +24,7 @@ describe('Rest parameters in functions', () => {
     fn(42, 'twenty three', 'win');
   });
   it('eliminate `arguments`!!!', () => {
-    //// const fn = () => arguments;
+    //// const fn = () => args;
     const fn = (...args) => args;
     const [firstArg, ...rest] = fn(1, 2, 3);
     assert.deepEqual([2, 3], rest);


### PR DESCRIPTION
…` test

the use of the `arguments` keyword makes mocha to hang indefinitely
without exit in case of the failure condition. This probably could
be because `arguments` is a reserved keyword and is not available in
arrow functions, but node / mocha is trying to access / execute it.
The change gives a more obvious hint to the solution, but would avoid
the indefinite hang of the test in the failure scenario.